### PR TITLE
Add the `activemodel` gem as a dependency.

### DIFF
--- a/music.gemspec
+++ b/music.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
 
   # Dependencies
   s.add_dependency              "activemodel", "~> 3.2"
-  s.add_development_dependency  "rake", ">= 0.9"
+  s.add_development_dependency  "rake", "~> 0.9"
   s.add_development_dependency  "bundler", "~> 1.1.3"
-  s.add_development_dependency  "rspec"
+  s.add_development_dependency  "rspec", '~> 2'
   s.add_development_dependency  "activemodel", '~> 3.2.0'
 end


### PR DESCRIPTION
This is a must; When adding `gem 'music'` to a Gemfile and running `bundle install` within an empty `rvm gemset` and attempting to use `music` within my code results in this error:

```
/lib/music/note.rb:1:in `require': cannot load such file -- active_model (LoadError)
```

I then have to add `gem 'activemodel'` to my Gemfile to get this to work. Adding `activemodel` as a dependency resolves this issue.

I've also changed the dependencies to use the `~>` syntax and removed the `rubygems_version` option (See commits description for reasoning behind these changes)

Cheers!
