### PR TITLE
Don't depend on certain version of Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,6 @@ PLATFORMS
 
 DEPENDENCIES
   activemodel (~> 3.2.0)
-  bundler (~> 1.2.4)
   guard-bundler
   guard-rspec
   music!

--- a/music.gemspec
+++ b/music.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   # Dependencies
   s.add_dependency              "activemodel", "~> 3.2"
   s.add_development_dependency  "rake", "~> 0.9"
-  s.add_development_dependency  "bundler", "~> 1.2.4"
   s.add_development_dependency  "rspec", '~> 2'
   s.add_development_dependency  "activemodel", '~> 3.2.0'
 end


### PR DESCRIPTION
If I don't have the locked version of Bundler as my `bundle` executable, then I won't be able to `bundle`. Also, I think you don't really _require_ that version of Bundler in your project; `guard-bundler` will take care of the version of Bundler if it has to.
