### PR TITLE
Remove ActiveModel and ActiveSupport

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,10 @@ PATH
   remote: .
   specs:
     music (0.6.2)
-      activemodel (~> 3.2)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.12)
-      activesupport (= 3.2.12)
-      builder (~> 3.0.0)
-    activesupport (3.2.12)
-      i18n (~> 0.6)
-      multi_json (~> 1.0)
-    builder (3.0.4)
     coderay (1.0.9)
     diff-lcs (1.2.1)
     guard (1.6.2)
@@ -28,11 +20,9 @@ GEM
     guard-rspec (2.4.1)
       guard (>= 1.1)
       rspec (~> 2.11)
-    i18n (0.6.1)
     listen (0.7.3)
     lumberjack (1.0.2)
     method_source (0.8.1)
-    multi_json (1.6.1)
     pry (0.9.12)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -55,7 +45,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel (~> 3.2.0)
   bundler (~> 1.2.4)
   guard-bundler
   guard-rspec

--- a/lib/music/chord.rb
+++ b/lib/music/chord.rb
@@ -97,7 +97,7 @@ module Music
         if note_string_match = chord_string.match(/^([A-Ga-g])([#b]?)([^\d]*)(\d*)$/)
           full_string, note, accidental, interval, octave = note_string_match.to_a
 
-          raise ArgumentError, 'No octave found and no octave assumed' if note.blank? && assumed_octave.nil?
+          raise ArgumentError, 'No octave found and no octave assumed' if note.empty? && assumed_octave.nil?
 
           Note.new(note + accidental + octave, assumed_octave).chord(interval)
         end

--- a/lib/music/note.rb
+++ b/lib/music/note.rb
@@ -1,15 +1,10 @@
-require 'active_model'
-
 module Music
   class Note
-    include ActiveModel::Validations
 
     NOTES = ['C', 'C#/Db', 'D', 'D#/Eb', 'E', 'F', 'F#/Gb', 'G', 'G#/Ab', 'A', 'A#/Bb', 'B']
     NOTE_STRINGS = ['Ab', 'A', 'A#', 'Bb', 'B', 'C', 'C#', 'Db', 'D', 'D#', 'Eb', 'E', 'F', 'Gb', 'G', 'G#']
 
     attr_accessor :frequency
-
-    validates_presence_of :frequency
 
     include Comparable
     def <=>(other_note)
@@ -227,7 +222,7 @@ module Music
     }
 
     def chord(description)
-      description = :major if description.blank?
+      description = :major if description.empty?
 
       description = description.to_s
       description.downcase! unless ['M', 'M7'].include?(description)
@@ -248,16 +243,14 @@ module Music
     end
 
     class << self
-      extend ActiveSupport::Memoizable
-
       def parse_note_string(note_string, assumed_octave = nil)
         match = note_string.match(/^([A-Ga-g])([#b]?)([0-8]?)$/)
 
         raise ArgumentError, "Did not recognize note string: #{note_string}" if !match
-        raise ArgumentError, "No octave found or specified" if match[3].blank? && assumed_octave.nil?
+        raise ArgumentError, "No octave found or specified" if match[3].empty? && assumed_octave.nil?
         raise ArgumentError if match[3].to_i > 8 || (assumed_octave && !(0..8).include?(assumed_octave))
 
-        octave = match[3].present? ? match[3] : assumed_octave
+        octave = match[3].empty? ? assumed_octave : match[3]
         [match[1].upcase, match[2] == '' ? nil : match[2], octave.to_i]
       end
 

--- a/music.gemspec
+++ b/music.gemspec
@@ -21,9 +21,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Dependencies
-  s.add_dependency              "activemodel", "~> 3.2"
   s.add_development_dependency  "rake", "~> 0.9"
   s.add_development_dependency  "bundler", "~> 1.2.4"
   s.add_development_dependency  "rspec", '~> 2'
-  s.add_development_dependency  "activemodel", '~> 3.2.0'
 end


### PR DESCRIPTION
The benefit from depending on ActiveModel and ActiveSupport are too small too keep them. They are very big dependencies. `validates_presence_of :frequency` isn't particularly useful, because
1. it will always be set, according to the constructor,
2. users won't call `#valid?`, because it just doesn't make sense in this project

All of this `#blank?` and `#present?` that I've replaced with `#empty?` are valid, because these variables will never be `nil`, since blank regular expression matches always return empty strings, never nils.
