### PR TITLE
Add support for parsing enharmonic notes such as 'E#5'

### DIFF
--- a/spec/classes/note_spec.rb
+++ b/spec/classes/note_spec.rb
@@ -12,6 +12,13 @@ describe Music::Note do
       Note.new(698.46).note_string.should eq('F5')
       Note.new(1975.53).note_string.should eq('B6')
     end
+
+    it 'should allow enharmonic note strings to initialize notes' do
+      Note.new('E#5').frequency.should eq(Note.new('F5').frequency)
+      Note.new('Fb5').frequency.should eq(Note.new('E5').frequency)
+      Note.new('B#5').frequency.should eq(Note.new('C5').frequency)
+      Note.new('Cb5').frequency.should eq(Note.new('B5').frequency)
+    end
   end
 
   describe 'Comparing notes' do


### PR DESCRIPTION
Fixes #8 

When initialising a note with an enharmonic note such as `E#5`, this PR adds support for parsing these notes and converting them to their enharmonic equivalent (`F5`) before calculating the frequency of the note.

I have added a unit test for this and all the other tests are passing.